### PR TITLE
Double speed.

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"fmt"
 	"math/big"
 )
 
@@ -22,10 +21,7 @@ func Reverse(n *big.Int) *big.Int {
 	ns := n.String()
 	nsr := strReverse(ns)
 	xr := new(big.Int)
-	xr, ok := xr.SetString(nsr, 10)
-	if !ok {
-		panic(fmt.Sprintf("Conversion error to big.Int: %v", nsr))
-	}
+	xr.SetString(nsr, 10)
 	return xr
 }
 
@@ -33,6 +29,14 @@ func Reverse(n *big.Int) *big.Int {
 // when being read from left to right and from right to left.
 // E.g. 121 is a palindrom number whereas 143 is not.
 func IsPalindromNumber(n *big.Int) bool {
-	h := Reverse(n)
-	return n.String() == h.String()
+	h:=n.String()
+	l:=len(h)
+	result := true
+	for i := 0; i < l/2; i++ {
+		if h[i] != h[l-i-1] {
+			result=false
+			break
+		}
+	}
+	return result
 }


### PR DESCRIPTION
Selbst ohne die char-compare Lösung wäre es deutlich schneller und simpler, wenn die  IsPalindromNumber keine BigInts erzeugen würde, sondern einfach strReverse statt Reverse aufrufen und die Stings vergleichen würde.

Und seit wann machst Du Go?